### PR TITLE
Added babel importer for downloaded fonts

### DIFF
--- a/buildprocess/configureWebpack.js
+++ b/buildprocess/configureWebpack.js
@@ -183,6 +183,14 @@ function configureWebpack(terriaJSBasePath, config, devMode, hot, MiniCssExtract
         }
     });
 
+    config.module.rules.push(
+        {
+            test: /\.(eot|woff|woff2|svg|ttf)([\?]?.*)$/,
+            include: path.resolve(terriaJSBasePath, '..', 'lib', 'fonts'),
+            loader: "file-loader",
+        }
+    )
+
     config.devServer = config.devServer || {
         stats: 'minimal',
         port: 3003,


### PR DESCRIPTION
> We need to add a babel importer for the new fonts that we downloaded to avoid using CDNs

### What this PR does

Fixes #<insert issue number here if relevant>

This is a description of what I've done in this PR, especially explaining choices made to make the reviewer's job easier. If I don't replace this paragraph with an actual description, my PR will probably be ignored.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated CHANGES.md with what I changed.
